### PR TITLE
Ref #506 add tzinfo for gmt time

### DIFF
--- a/flickr_exporter.py
+++ b/flickr_exporter.py
@@ -3,6 +3,7 @@ from flickr_warc_iter import FlickrWarcIter, TYPE_FLICKR_PHOTO
 import logging
 import time
 from dateutil.parser import parse as date_parse
+from dateutil.tz import tzutc
 
 log = logging.getLogger(__name__)
 
@@ -31,7 +32,8 @@ class FlickrPhotoTable(BaseTable):
         return (item["id"],
                 # date posted is gmt epoch time, convert it to the same format as date taken
                 # detail as https://www.flickr.com/services/api/misc.dates.html
-                date_parse(time.strftime("%Y-%m-%d %H:%M:%S", time.gmtime(float(item["dates"]["posted"])))),
+                date_parse(time.strftime("%Y-%m-%d %H:%M:%S",
+                                         time.gmtime(float(item["dates"]["posted"])))).replace(tzinfo=tzutc()),
                 date_parse(item["dates"]["taken"]), item["license"], item["safety_level"],
                 item.get("originalformat"), item["owner"]["nsid"], item["owner"]["username"],
                 item["title"]["_content"].replace('\n', ' '),


### PR DESCRIPTION
Ref https://github.com/gwu-libraries/sfm-ui/issues/505
* add time zone info for `date_posted`
* for the `date_taken`, it might be not friendly display the timezone info. As the official says [here](https://www.flickr.com/services/api/misc.dates.html)